### PR TITLE
DOCKERFILE: Specified Alpine 3.5

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM golang:alpine
+FROM alpine:3.5
 MAINTAINER Jimmy Zelinskie <jimmyzelinskie@gmail.com>
 
 # Install OS-level dependencies.


### PR DESCRIPTION
Alpine doesn't contain root certificates prior to 3.4, forcing use of the latest stable release